### PR TITLE
Makefile: target for updating documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,12 @@ doc:
 clean:
 	dune clean
 
-.PHONY: all doc clean
+pushdoc:
+	git stash
+	dune build @doc
+	git checkout gh-pages || git checkout --orphan gh-pages
+	cp -r _build/default/_doc/_html/* . && git add .
+	git commit --allow-empty -am "update documentation" && git push
+	git checkout master && git stash pop
+
+.PHONY: all doc clean pushdoc


### PR DESCRIPTION
I added a Makefile target for building the documentation and pushing it to the `gh-pages` branch.

In order to publish the documentation (on https://Armael.github.io/pp_loc), you still have to flip a switch in the repository settings: https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages#enabling-github-pages-to-publish-your-site-from-master-or-gh-pages