### PR TITLE
remove unnecessary dependency on stdlib-shims

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,6 @@
   (depends
     (ocaml (>= 4.08.0))
     (dune (>= 1.10))
-    (stdlib-shims (<> 0))
     (odoc :with-doc)
   )
   (synopsis "Quote and highlight input fragments at a given source location")

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,2 @@
 (library
-  (public_name pp_loc)
-  (libraries stdlib-shims))
+  (public_name pp_loc))

--- a/pp_loc.opam
+++ b/pp_loc.opam
@@ -23,6 +23,5 @@ This library provides support for quoting and highlighting the input fragment th
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.10"}
-  "stdlib-shims" {!= "0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
since 4.08 is the minimum requirement here, stdlib will always be around :)