### PR TITLE
line_offsets index, abstract positions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ doc:
 clean:
 	dune clean
 
+watch:
+	dune build @install -w
+
 pushdoc:
 	git stash
 	dune build @doc

--- a/lib/dune
+++ b/lib/dune
@@ -1,2 +1,3 @@
 (library
+  (private_modules line_offsets)
   (public_name pp_loc))

--- a/lib/line_offsets.ml
+++ b/lib/line_offsets.ml
@@ -1,0 +1,84 @@
+
+(* A very basic dynamic array. *)
+module Vec = struct
+  type 'a t = {
+    mutable arr: 'a array;
+    mutable sz: int;
+  }
+
+  let create() : _ t = { arr=[||]; sz=0 }
+
+  let grow_ self x =
+    let new_size = max 6 (let n = Array.length self.arr in n + n / 2 + 1) in
+    let arr = Array.make new_size x in
+    Array.blit self.arr 0 arr 0 self.sz;
+    self.arr <- arr
+
+  let push (self:_ t) x =
+    if self.sz = Array.length self.arr then grow_ self x;
+    self.arr.(self.sz) <- x;
+    self.sz <- 1 + self.sz
+
+  let to_array self = Array.sub self.arr 0 self.sz
+end
+
+type t = int array
+
+let from_string (s:string) : t =
+  let lines = Vec.create() in
+  Vec.push lines 0; (* first line is free *)
+  let size = String.length s in
+  let i = ref 0 in
+  while !i < size do
+    match String.index_from_opt s !i '\n' with
+    | None -> i := size
+    | Some j ->
+      Vec.push lines j;
+      i := j+1;
+  done;
+  Vec.to_array lines
+
+let from_chan (cin:in_channel) : t =
+  let buf = Buffer.create 1024 in
+  (try while true do Buffer.add_channel buf cin (16 * 1024) done; assert false
+   with End_of_file -> ());
+  from_string (Buffer.contents buf)
+
+let find_line_offset (self:t) ~line : int =
+  let line = line-1 in
+  if line >= Array.length self then (
+    Array.length self
+  ) else (
+    self.(line)
+  )
+
+let find_offset (self:t) ~line ~col : int =
+  let off = find_line_offset self ~line in
+  off + (col - 1)
+
+let line_col_of_offset (self:t) (off:int) : int * int =
+  (* binary search *)
+  let low = ref 0 in
+  let high = ref (Array.length self) in
+  let continue = ref true in
+  while !continue && !low < !high do
+    let middle = !low / 2 + !high / 2 in
+    let off_middle = self.(middle) in
+
+    if off_middle <= off then (
+      if middle + 1 = Array.length self ||
+         self.(middle + 1) > off then (
+        (* found the range *)
+        low := middle;
+        continue := false;
+      ) else (
+        low := middle + 1;
+      )
+    ) else (
+      high := middle - 1;
+    )
+  done;
+  let col = off - self.(!low) + 1 in
+  let line = !low + 1 in
+  line, col
+;;

--- a/lib/line_offsets.mli
+++ b/lib/line_offsets.mli
@@ -1,0 +1,14 @@
+
+(* compute line offsets *)
+
+type t = int array
+
+val from_chan : in_channel -> t
+
+val from_string : string -> t
+
+val find_line_offset : t -> line:int -> int
+
+val find_offset : t -> line:int -> col:int -> int
+
+val line_col_of_offset : t -> int -> int * int

--- a/lib/pp_loc.ml
+++ b/lib/pp_loc.ml
@@ -1,6 +1,3 @@
-open Lexing
-
-type loc = position * position
 
 let rec list_find_map f = function
   | [] -> None
@@ -49,13 +46,17 @@ module Input = struct
   type raw = {
     seek : int -> (unit, [`Invalid_position]) result;
     read_char : unit -> (char, [`End_of_input]) result;
+    line_offsets : int array lazy_t;
   }
 
   type t =
     | Raw of raw
     | Managed of (unit -> t * (unit -> unit))
 
-  let raw ~seek ~read_char = Raw { seek; read_char }
+  let raw ~seek ~read_char ~line_offsets =
+    let line_offsets = lazy (line_offsets()) in
+    Raw { seek; read_char; line_offsets; }
+
   let managed create = Managed create
 
   let in_channel cin =
@@ -64,7 +65,8 @@ module Input = struct
     let read_char () =
       try Ok (input_char cin)
       with End_of_file | Sys_error _ -> Error `End_of_input in
-    Raw { seek; read_char }
+    let line_offsets = lazy (Line_offsets.from_chan cin) in
+    Raw { seek; read_char; line_offsets }
 
   let file name =
     managed (fun () ->
@@ -75,6 +77,7 @@ module Input = struct
     (b: 'a)
     ~(len: 'a -> int)
     ~(read: 'a -> int -> char)
+    ~(to_string : 'a -> string)
     =
     let cur_pos = ref (-1) in
     let inbound i = i >= 0 && i < len b in
@@ -90,10 +93,11 @@ module Input = struct
         incr cur_pos;
         Ok c
     in
-    Raw { seek; read_char }
+    let line_offsets = lazy (Line_offsets.from_string (to_string b)) in
+    Raw { seek; read_char; line_offsets }
 
-  let string s = buf s ~len:String.length ~read:String.get
-  let bytes b = buf b ~len:Bytes.length ~read:Bytes.get
+  let string s = buf s ~len:String.length ~read:String.get ~to_string:(fun s -> s)
+  let bytes b = buf b ~len:Bytes.length ~read:Bytes.get ~to_string:Bytes.unsafe_to_string
 
   (*****)
 
@@ -104,6 +108,37 @@ module Input = struct
       let r, c' = open_raw i in
       r, (fun () -> c' (); c ())
 end
+
+
+(******************************************************************************)
+(* Positions and locations *)
+
+module Position = struct
+  type t =
+    | Offset of int
+    | Line_col of int * int
+    | Full of Lexing.position
+
+  let of_lexing pos = Full pos
+  let of_offset i = Offset i
+  let of_line_col l c = Line_col (l, c)
+
+  let to_full (input:Input.raw) (self:t) : Lexing.position =
+    match self with
+    | Full pos -> pos
+    | Offset offset ->
+      let lazy index = input.Input.line_offsets in
+      let line, col = Line_offsets.line_col_of_offset index offset in
+      {Lexing.pos_cnum=col; pos_lnum=line; pos_bol=offset-col;
+       pos_fname="";}
+    | Line_col(line,col) ->
+      let lazy index = input.Input.line_offsets in
+      let offset = Line_offsets.find_offset index ~line ~col in
+      {Lexing.pos_cnum=col; pos_lnum=line; pos_bol=offset-col;
+       pos_fname="";}
+end
+
+type loc = Position.t * Position.t
 
 (******************************************************************************)
 (* Format highlighting tags *)
@@ -266,10 +301,11 @@ let infer_line_numbers
    reads from a file.
 *)
 let highlight_quote ppf
-    ~(get_lines: start_pos:position -> end_pos:position -> input_line list)
+    ~(get_lines: start_pos:Lexing.position -> end_pos:Lexing.position -> input_line list)
     ~(max_lines: int)
     locs
   =
+  let open Lexing in
   let iset = ISet.of_intervals @@ list_filter_map (fun (s, e) ->
     if s.pos_cnum = -1 || e.pos_cnum = -1 then None
     else Some ((s, s.pos_cnum), (e, e.pos_cnum - 1))
@@ -323,7 +359,7 @@ let highlight_quote ppf
     Format.fprintf ppf "@]"
 
 let lines_around
-    ~(start_pos: position) ~(end_pos: position)
+    ~(start_pos: Lexing.position) ~(end_pos: Lexing.position)
     ~(input: Input.raw):
   input_line list
   =
@@ -366,6 +402,23 @@ let pp
     (ppf: Format.formatter)
     (locs: loc list)
   =
+
+  (* convert locations so that the positions are full lexing positions *)
+  let locs = match locs with
+    | [] -> []
+    | _ ->
+      let input_raw, close_input = Input.open_raw input in
+      let locs =
+        List.map
+          (fun (start_pos,end_pos) ->
+             Position.to_full input_raw start_pos,
+             Position.to_full input_raw end_pos)
+          locs
+      in
+      close_input ();
+      locs
+  in
+
   (* The fact that [get_lines] is only called once by [highlight_quote] is
      important here, because it might consume the input... *)
   let get_lines ~start_pos ~end_pos =

--- a/lib/pp_loc.mli
+++ b/lib/pp_loc.mli
@@ -1,5 +1,26 @@
+
+(** A position in a file or string.
+
+    It is abstract to provide more flexibility than {!Lexing.position}.
+
+    @since 2.0
+*)
+module Position : sig
+  type t
+
+  val of_lexing : Lexing.position -> t
+
+  val of_offset : int -> t
+
+  val of_line_col : int -> int -> t
+  (** [of_line_col line col] builds the position indicating the character
+      at column [col] and line [line] of the input.
+      @since 2.0
+  *)
+end
+
 (** The type of source locations: start position, end position *)
-type loc = Lexing.position * Lexing.position
+type loc = Position.t * Position.t
 
 (** Abstraction over the input containing the input to read from. *)
 module Input : sig
@@ -26,17 +47,26 @@ module Input : sig
 
   (** {2 Low-level functions} *)
 
-  (** Creates an input from functions [seek] and [read].
+  (** Creates an input from functions.
 
-      The function [seek] will be called once, before any call to [read_char].
-     If the call to [seek] fails and returns [Error `Invalid_position], the
-     input is considered to be unreadable and will be treated equivalenty as the
-     empty input. This might happen even if the input is valid, if one tries to
-     highlight an invalid location.
+      @param [seek] is a function to move to a given offset in the input.
+      It will be called once, before any call to [read_char].
+      If the call to [seek] fails and returns [Error `Invalid_position], the
+      input is considered to be unreadable and will be treated equivalenty as the
+      empty input. This might happen even if the input is valid, if one tries to
+      highlight an invalid location.
+
+      @param read_char is used to read the next char from the currently seeked
+      position, and seek one char forward.
+
+      @param line_offsets computes the byte offset of each line in the file.
+      This is used when positions are built from only an offset, or only
+      a pair [(line,column)].
   *)
   val raw :
     seek: (int -> (unit, [`Invalid_position]) result) ->
     read_char: (unit -> (char, [`End_of_input]) result) ->
+    line_offsets: (unit -> int array) ->
     t
 
   (** [managed f] enables creating an input which lifetime is managed


### PR DESCRIPTION
this follows discussions about parsers where the full `Lexing.position` isn't stored for each AST node, or parsers that don't even use `Lexing`. In that case it can be convenient to only store offsets, or only store line/col pairs. This PR implements a converter that uses a `int array` internally to map each line number to its corresponding offset in the input.